### PR TITLE
Fixed the null-pointer exception while loading the plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ group = 'com.thoughtworks.gocd'
 
 gocdPlugin {
   id = 'com.thoughtworks.gocd.authorization.ldap'
-  pluginVersion = '4.0.0'
+  pluginVersion = '4.0.1'
   goCdVersion = '19.2.0'
   name = 'LDAP Authorization Plugin for GoCD'
   description = 'LDAP Authorization Plugin for GoCD'

--- a/src/main/java/com/thoughtworks/gocd/authorization/ldap/utils/Util.java
+++ b/src/main/java/com/thoughtworks/gocd/authorization/ldap/utils/Util.java
@@ -58,18 +58,18 @@ public class Util {
         try {
             Properties properties = new Properties();
             properties.load(new StringReader(s));
-            return (String) properties.get("pluginId");
+            return (String) properties.get("id");
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
 
     public static String fullVersion() {
-        String s = readResource("/version.properties");
+        String s = readResource("/plugin.properties");
         try {
             Properties properties = new Properties();
             properties.load(new StringReader(s));
-            return (String) properties.get("fullVersion");
+            return (String) properties.get("version");
         } catch (IOException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
Issue: #12 

The plugin was trying to print a message with the plugin id and GoCD version from the file `version.properties` which was deleted in favour of `plugin.properties`.